### PR TITLE
Some code blocks do not look good on github's readme view.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ Installation
 
 * Add the following entry to ``deps`` then run ``php bin/vendors install``::
 
+    ```
     [goutte]
         git=git://github.com/fabpot/Goutte.git
+    ```
 
 * Register the bundle in ``app/AppKernel.php``::
 
+    ```php
     <?php
 
     // app/AppKernel.php
@@ -25,14 +28,17 @@ Installation
             // ...
         );
     }
+    ```
 
 * Register namespaces in ``app/autoload.php``::
 
+    ```php
     $loader->registerNamespaces(array(
         // ...
         'Goutte'           => __DIR__.'/../vendor/goutte/src',
         'Sonata'           => __DIR__.'/../vendor/bundles',
     ));
+    ```
     
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -9,37 +9,37 @@ Installation
 
 * Add the following entry to ``deps`` then run ``php bin/vendors install``::
 
-    ```
-    [goutte]
-        git=git://github.com/fabpot/Goutte.git
-    ```
+```
+[goutte]
+    git=git://github.com/fabpot/Goutte.git
+```
 
 * Register the bundle in ``app/AppKernel.php``::
 
-    ```php
-    <?php
+```php
+<?php
 
-    // app/AppKernel.php
-    public function registerBundles()
-    {
-        return array(
-            // ...
-            new Sonata\GoutteBundle\SonataGoutteBundle(),
-            // ...
-        );
-    }
-    ```
+// app/AppKernel.php
+public function registerBundles()
+{
+    return array(
+        // ...
+        new Sonata\GoutteBundle\SonataGoutteBundle(),
+        // ...
+    );
+}
+```
 
 * Register namespaces in ``app/autoload.php``::
 
-    ```php
-    <?php
-    $loader->registerNamespaces(array(
-        // ...
-        'Goutte'           => __DIR__.'/../vendor/goutte/src',
-        'Sonata'           => __DIR__.'/../vendor/bundles',
-    ));
-    ```
+```php
+<?php
+$loader->registerNamespaces(array(
+    // ...
+    'Goutte'           => __DIR__.'/../vendor/goutte/src',
+    'Sonata'           => __DIR__.'/../vendor/bundles',
+));
+```
     
 Configuration
 -------------
@@ -47,43 +47,43 @@ Configuration
 * edit app/autoload.php and AppKernel.php to add the appropriate lines for the Sonata namespace.
 * edit your config.yml and add these lines
 
-    ```yaml
-    sonata_goutte:
-        class: Sonata\GoutteBundle\Manager
-        clients:
-            default:
-                config:
-                    adapter: Zend\Http\Client\Adapter\Socket
+```yaml
+sonata_goutte:
+    class: Sonata\GoutteBundle\Manager
+    clients:
+        default:
+            config:
+                adapter: Zend\Http\Client\Adapter\Socket
 
-            curl:
-                config:
-                    maxredirects: 0
-                    timeout: 30
-                    useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3
-                    adapter: Sonata\GoutteBundle\Adapter\Curl
-                    verbose_log: %kernel.logs_dir%/curl.log
-                    verbose: true
-    ```
+        curl:
+            config:
+                maxredirects: 0
+                timeout: 30
+                useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3
+                adapter: Sonata\GoutteBundle\Adapter\Curl
+                verbose_log: %kernel.logs_dir%/curl.log
+                verbose: true
+```
 
 Usage
 -----
 
-    ```php
-    <?php
-    public function fetchAction()
-    {
-        $client = $this->get('goutte')
-            ->getNamedClient('curl');
+```php
+<?php
+public function fetchAction()
+{
+    $client = $this->get('goutte')
+        ->getNamedClient('curl');
 
-        $crawler = $client->request('GET', 'http://symfony-reloaded.org/');
+    $crawler = $client->request('GET', 'http://symfony-reloaded.org/');
 
-        $response = $client->getResponse();
+    $response = $client->getResponse();
 
-        $content = $response->getContent();
+    $content = $response->getContent();
 
-        // do stuff with the crawler and related information
-    }
-    ```
+    // do stuff with the crawler and related information
+}
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configuration
 * edit app/autoload.php and AppKernel.php to add the appropriate lines for the Sonata namespace.
 * edit your config.yml and add these lines
 
-        ```yaml
+    ```yaml
         sonata_goutte:
             class: Sonata\GoutteBundle\Manager
             clients:
@@ -63,12 +63,12 @@ Configuration
                         adapter: Sonata\GoutteBundle\Adapter\Curl
                         verbose_log: %kernel.logs_dir%/curl.log
                         verbose: true
-        ```
+    ```
 
 Usage
 -----
         
-        ```php
+   ```php
         public function fetchAction()
         {
             $client = $this->get('goutte')
@@ -82,7 +82,7 @@ Usage
 
             // do stuff with the crawler and related information
         }
-        ```
+    ```
 
 
 

--- a/README.md
+++ b/README.md
@@ -48,40 +48,40 @@ Configuration
 * edit your config.yml and add these lines
 
     ```yaml
-        sonata_goutte:
-            class: Sonata\GoutteBundle\Manager
-            clients:
-                default:
-                    config:
-                        adapter: Zend\Http\Client\Adapter\Socket
+    sonata_goutte:
+        class: Sonata\GoutteBundle\Manager
+        clients:
+            default:
+                config:
+                    adapter: Zend\Http\Client\Adapter\Socket
 
-                curl:
-                    config:
-                        maxredirects: 0
-                        timeout: 30
-                        useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3
-                        adapter: Sonata\GoutteBundle\Adapter\Curl
-                        verbose_log: %kernel.logs_dir%/curl.log
-                        verbose: true
+            curl:
+                config:
+                    maxredirects: 0
+                    timeout: 30
+                    useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3
+                    adapter: Sonata\GoutteBundle\Adapter\Curl
+                    verbose_log: %kernel.logs_dir%/curl.log
+                    verbose: true
     ```
 
 Usage
 -----
         
-   ```php
-        public function fetchAction()
-        {
-            $client = $this->get('goutte')
-                ->getNamedClient('curl');
+    ```php
+    public function fetchAction()
+    {
+        $client = $this->get('goutte')
+            ->getNamedClient('curl');
 
-            $crawler = $client->request('GET', 'http://symfony-reloaded.org/');
+        $crawler = $client->request('GET', 'http://symfony-reloaded.org/');
 
-            $response = $client->getResponse();
+        $response = $client->getResponse();
 
-            $content = $response->getContent();
+        $content = $response->getContent();
 
-            // do stuff with the crawler and related information
-        }
+        // do stuff with the crawler and related information
+    }
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Installation
 * Register namespaces in ``app/autoload.php``::
 
     ```php
+    <?php
     $loader->registerNamespaces(array(
         // ...
         'Goutte'           => __DIR__.'/../vendor/goutte/src',

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Configuration
 
 Usage
 -----
-        
+
     ```php
+    <?php
     public function fetchAction()
     {
         $client = $this->get('goutte')

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Configuration
 * edit app/autoload.php and AppKernel.php to add the appropriate lines for the Sonata namespace.
 * edit your config.yml and add these lines
 
+        ```yaml
         sonata_goutte:
             class: Sonata\GoutteBundle\Manager
             clients:
@@ -62,11 +63,12 @@ Configuration
                         adapter: Sonata\GoutteBundle\Adapter\Curl
                         verbose_log: %kernel.logs_dir%/curl.log
                         verbose: true
-
+        ```
 
 Usage
 -----
-
+        
+        ```php
         public function fetchAction()
         {
             $client = $this->get('goutte')
@@ -80,7 +82,7 @@ Usage
 
             // do stuff with the crawler and related information
         }
-
+        ```
 
 
 


### PR DESCRIPTION
Some code blocks do not look properly for the moment. In markdown code blocks works with spaces, not with tabs. I'm trying the other methods, which use a triple ` + the name of the language. It is supposed to offer syntax highlighting. Read about it here : http://github.github.com/github-flavored-markdown/
