### PR TITLE
Why not show how to get the bundle's sources too?

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Installation
 ```
 [goutte]
     git=git://github.com/fabpot/Goutte.git
+[SonataGoutteBundle]
+    git=http://github.com/sonata-project/SonataGoutteBundle.git
+    target=/bundles/Sonata/GoutteBundle
 ```
 
 * Register the bundle in ``app/AppKernel.php``::


### PR DESCRIPTION
Is this an oversight or is there a reason not to specify it (the existence of other installation methods, maybe)?
