### PR TITLE
goutte has changed!

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Installation
 ```
 [goutte]
     git=git://github.com/fabpot/Goutte.git
+    version=5ecceb7c28a428fb93f283982cc4f5edfd96630b
+
 [SonataGoutteBundle]
     git=http://github.com/sonata-project/SonataGoutteBundle.git
     target=/bundles/Sonata/GoutteBundle


### PR DESCRIPTION
There is no src directory anymore!
Provide recommandations in the installation doc: I choosed the latest known working-for-me commit.
