### PR TITLE
Default useragent can cause wrong response

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sonata_goutte:
             config:
                 maxredirects: 0
                 timeout: 30
-                useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3
+                useragent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US) Gecko/20100401 Firefox/3.6.3
                 adapter: Sonata\GoutteBundle\Adapter\Curl
                 verbose_log: %kernel.logs_dir%/curl.log
                 verbose: true


### PR DESCRIPTION
Some versions of IIS server, I think buggy versions, generate response with status code 400 using the user agent from default configuration.

I don't know if the problem can be related also to Goutte or Zend\HTTP but a little change on the default value can avoid some "false negative" results.
